### PR TITLE
Fix chat font on resolutions higher than 1080p

### DIFF
--- a/src/client/module/patches.cpp
+++ b/src/client/module/patches.cpp
@@ -182,6 +182,17 @@ namespace patches
 
 			return game::Sys_Milliseconds();
 		}
+
+		game::Font_s* get_chat_font_handle()
+		{
+			static game::Font_s* chat_font = nullptr;
+			if (chat_font == nullptr)
+			{
+				chat_font = game::R_RegisterFont("fonts/bigFont");
+			}
+
+			return chat_font;
+		}
 	}
 
 	class module final : public module_interface
@@ -318,6 +329,11 @@ namespace patches
 
 			// Enable DLC items, extra loadouts and map selection in extinction
 			dvar_register_int_hook.create(0x1404EE270, &dvar_register_int);
+
+			// patch game chat on resolutions higher than 1080p to use the right font
+			utils::hook::call(0x14025C825, get_chat_font_handle);
+			utils::hook::call(0x1402BC42F, get_chat_font_handle);
+			utils::hook::call(0x1402C3699, get_chat_font_handle);
 		}
 
 		void patch_sp() const

--- a/src/client/module/patches.cpp
+++ b/src/client/module/patches.cpp
@@ -185,13 +185,7 @@ namespace patches
 
 		game::Font_s* get_chat_font_handle()
 		{
-			static game::Font_s* chat_font = nullptr;
-			if (chat_font == nullptr)
-			{
-				chat_font = game::R_RegisterFont("fonts/bigFont");
-			}
-
-			return chat_font;
+			return game::R_RegisterFont("fonts/bigFont");
 		}
 	}
 


### PR DESCRIPTION
On resolutions higher than 1080 the game decides to use "fonts/extraBigFont" instead of "fonts/bigFont" to draw the chat fields. This makes the text very stretched and long messages cover half of your screen. See pics below

Before
![3pMriUk](https://user-images.githubusercontent.com/31417080/98264687-28f93000-1f56-11eb-9355-01868b08efdd.jpeg)

After
![fixed](https://user-images.githubusercontent.com/31417080/98264689-2a2a5d00-1f56-11eb-8649-c3bfc23d21d9.jpg)
