### PR TITLE
Change steam_id generation to a more suitable random

### DIFF
--- a/src/client/game/game.cpp
+++ b/src/client/game/game.cpp
@@ -58,6 +58,7 @@ namespace game
 
 	Material_RegisterHandle_t Material_RegisterHandle;
 
+	NET_OutOfBandPrint_t NET_OutOfBandPrint;
 	NET_StringToAdr_t NET_StringToAdr;
 
 	R_AddCmdDrawStretchPic_t R_AddCmdDrawStretchPic;
@@ -244,6 +245,7 @@ namespace game
 
 			Material_RegisterHandle = Material_RegisterHandle_t(SELECT_VALUE(0x140523D90, 0x1405F0E20));
 
+			NET_OutOfBandPrint = NET_OutOfBandPrint_t(SELECT_VALUE(0, 0x14041D5C0));
 			NET_StringToAdr = NET_StringToAdr_t(SELECT_VALUE(0, 0x14041D870));
 
 			R_AddCmdDrawStretchPic = R_AddCmdDrawStretchPic_t(SELECT_VALUE(0x140234460, 0x140600BE0));

--- a/src/client/game/game.hpp
+++ b/src/client/game/game.hpp
@@ -134,6 +134,9 @@ namespace game
 	typedef Material* (*Material_RegisterHandle_t)(const char* material);
 	extern Material_RegisterHandle_t Material_RegisterHandle;
 
+	typedef void (*NET_OutOfBandPrint_t)(netsrc_t, netadr_s*, const char*);
+	extern NET_OutOfBandPrint_t NET_OutOfBandPrint;
+
 	typedef bool (*NET_StringToAdr_t)(const char* s, game::netadr_s* a);
 	extern NET_StringToAdr_t NET_StringToAdr;
 

--- a/src/client/module/network.cpp
+++ b/src/client/module/network.cpp
@@ -83,6 +83,15 @@ namespace network
 		{
 			return net_compare_base_address(a1, a2) && a1->port == a2->port;
 		}
+
+		void reconnect_migratated_client(game::mp::client_t*, game::netadr_s* from, const int, const int, const char*, const char*, bool)
+		{
+			// This happens when a client tries to rejoin after being recently disconnected, OR by a duplicated guid
+			// We don't want this to do anything. It decides to crash seemingly randomly
+			// Rather than try and let the player in, just tell them they are a duplicate player and reject connection
+			
+			game::NET_OutOfBandPrint(game::NS_SERVER, from, "error\nYou are already connected to the server.");
+		}
 	}
 
 	void on(const std::string& command, const callback& callback)
@@ -233,6 +242,9 @@ namespace network
 
 				// don't read checksum
 				utils::hook::jump(0x1405019CB, 0x1405019F3);
+
+				// don't try to reconnect client
+				utils::hook::call(0x14047197E, reconnect_migratated_client);
 
 				// ignore built in "print" oob command and add in our own
 				utils::hook::set<uint8_t>(0x1402C6AA4, 0xEB);

--- a/src/client/steam/interfaces/user.cpp
+++ b/src/client/steam/interfaces/user.cpp
@@ -2,8 +2,6 @@
 #include "steam/steam.hpp"
 #include "utils/cryptography.hpp"
 
-using namespace utils;
-
 namespace steam
 {
 	namespace
@@ -13,7 +11,7 @@ namespace steam
 		steam_id generate_steam_id()
 		{
 			steam_id id;
-			id.bits = 0x110000100000000 | (cryptography::random::get_integer());
+			id.bits = 0x110000100000000 | (::utils::cryptography::random::get_integer());
 			return id;
 		}
 	}

--- a/src/client/steam/interfaces/user.cpp
+++ b/src/client/steam/interfaces/user.cpp
@@ -11,7 +11,7 @@ namespace steam
 		steam_id generate_steam_id()
 		{
 			steam_id id;
-			id.bits = 0x110000100000000 | (::utils::cryptography::random::get_integer());
+			id.bits = 0x110000100000000 | (::utils::cryptography::random::get_integer() & ~0x80000000);
 			return id;
 		}
 	}

--- a/src/client/steam/interfaces/user.cpp
+++ b/src/client/steam/interfaces/user.cpp
@@ -1,5 +1,8 @@
 #include <std_include.hpp>
 #include "steam/steam.hpp"
+#include "utils/cryptography.hpp"
+
+using namespace utils;
 
 namespace steam
 {
@@ -9,10 +12,8 @@ namespace steam
 
 		steam_id generate_steam_id()
 		{
-			srand(uint32_t(time(nullptr)));
-
 			steam_id id;
-			id.bits = 0x110000100000000 | (rand() & ~0x80000000);
+			id.bits = 0x110000100000000 | (cryptography::random::get_integer());
 			return id;
 		}
 	}


### PR DESCRIPTION
The old steam id generation was not random enough and caused collisions to happen across players. When two players with the same id tried to join a server, there would be a crash rooting in SV_DirectConnect because it thought it needed to reconnect a player that was already in the session state. Temporary fix for now, some method to guarantee no collisions may be needed down the road