### PR TITLE
add fast_restart command

### DIFF
--- a/src/client/game/game.cpp
+++ b/src/client/game/game.cpp
@@ -87,6 +87,7 @@ namespace game
 	SV_AddBot_t SV_AddBot;
 	SV_BotIsBot_t SV_BotIsBot;
 	SV_ExecuteClientCommand_t SV_ExecuteClientCommand;
+	SV_FastRestart_t SV_FastRestart;
 	SV_GetPlayerstateForClientNum_t SV_GetPlayerstateForClientNum;
 	SV_GetGuid_t SV_GetGuid;
 	SV_KickClientNum_t SV_KickClientNum;
@@ -279,6 +280,7 @@ namespace game
 			SV_AddBot = SV_AddBot_t(SELECT_VALUE(0, 0x140470920));
 			SV_BotIsBot = SV_BotIsBot_t(SELECT_VALUE(0, 0x140461340));
 			SV_ExecuteClientCommand = SV_ExecuteClientCommand_t(SELECT_VALUE(0, 0x140472430));
+			SV_FastRestart = SV_FastRestart_t(SELECT_VALUE(0x14048B890, 0x14046F440));
 			SV_GetPlayerstateForClientNum = SV_GetPlayerstateForClientNum_t(SELECT_VALUE(0x140490F80, 0x140475A10));
 			SV_GetGuid = SV_GetGuid_t(SELECT_VALUE(0, 0x140475990));
 			SV_KickClientNum = SV_KickClientNum_t(SELECT_VALUE(0, 0x14046F730));

--- a/src/client/game/game.hpp
+++ b/src/client/game/game.hpp
@@ -199,6 +199,9 @@ namespace game
 	typedef void (*SV_ExecuteClientCommand_t)(mp::client_t*, const char*, int);
 	extern SV_ExecuteClientCommand_t SV_ExecuteClientCommand;
 
+	typedef void (*SV_FastRestart_t)();
+	extern SV_FastRestart_t SV_FastRestart;
+
 	typedef playerState_s* (*SV_GetPlayerstateForClientNum_t)(int num);
 	extern SV_GetPlayerstateForClientNum_t SV_GetPlayerstateForClientNum;
 

--- a/src/client/module/bots.cpp
+++ b/src/client/module/bots.cpp
@@ -11,27 +11,42 @@ namespace bots
 {
 	namespace
 	{
+		void bot_team(const int entity_num)
+		{
+			if (game::SV_BotIsBot(game::mp::g_entities[entity_num].s.clientNum))
+			{
+				if (game::mp::g_entities[entity_num].client->sess.cs.team == game::mp::team_t::TEAM_SPECTATOR)
+				{
+					// schedule the select team call
+					scheduler::once([entity_num]()
+					{
+						game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
+							utils::string::va("lui 68 2 %i", *game::mp::sv_serverId_value),
+							false);
+
+						// scheduler the select class call
+						scheduler::once([entity_num]()
+						{
+							game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
+								utils::string::va("lui 5 %i %i", (rand() % 5) + 10,
+									*game::mp::sv_serverId_value), false);
+						}, scheduler::pipeline::server, 1s);
+					}, scheduler::pipeline::server, 1s);
+				}
+
+				scheduler::once([entity_num]()
+				{
+					bot_team(entity_num);
+				}, scheduler::pipeline::server, 3s);
+			}
+		}
+
 		void spawn_bot(const int entity_num)
 		{
 			scheduler::once([entity_num]()
 			{
 				game::SV_SpawnTestClient(&game::mp::g_entities[entity_num]);
-
-				// schedule the select team call
-				scheduler::once([entity_num]()
-				{
-					game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
-					                              utils::string::va("lui 68 2 %i", *game::mp::sv_serverId_value),
-					                              false);
-
-					// scheduler the select class call
-					scheduler::once([entity_num]()
-					{
-						game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
-						                              utils::string::va("lui 5 %i %i", (rand() % 5) + 10,
-						                                                *game::mp::sv_serverId_value), false);
-					}, scheduler::pipeline::server, 1s);
-				}, scheduler::pipeline::server, 1s);
+				bot_team(entity_num);
 			}, scheduler::pipeline::server, 1s);
 		}
 

--- a/src/client/module/bots.cpp
+++ b/src/client/module/bots.cpp
@@ -11,27 +11,32 @@ namespace bots
 {
 	namespace
 	{
+		void bot_team_join(const int entity_num)
+		{
+			// schedule the select team call
+			scheduler::once([entity_num]()
+			{
+				game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
+					utils::string::va("lui 68 2 %i", *game::mp::sv_serverId_value),
+					false);
+
+				// scheduler the select class call
+				scheduler::once([entity_num]()
+				{
+					game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
+						utils::string::va("lui 5 %i %i", (rand() % 5) + 10,
+							*game::mp::sv_serverId_value), false);
+				}, scheduler::pipeline::server, 1s);
+			}, scheduler::pipeline::server, 1s);
+		}
+
 		void bot_team(const int entity_num)
 		{
 			if (game::SV_BotIsBot(game::mp::g_entities[entity_num].s.clientNum))
 			{
 				if (game::mp::g_entities[entity_num].client->sess.cs.team == game::mp::team_t::TEAM_SPECTATOR)
 				{
-					// schedule the select team call
-					scheduler::once([entity_num]()
-					{
-						game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
-							utils::string::va("lui 68 2 %i", *game::mp::sv_serverId_value),
-							false);
-
-						// scheduler the select class call
-						scheduler::once([entity_num]()
-						{
-							game::SV_ExecuteClientCommand(&game::mp::svs_clients[entity_num],
-								utils::string::va("lui 5 %i %i", (rand() % 5) + 10,
-									*game::mp::sv_serverId_value), false);
-						}, scheduler::pipeline::server, 1s);
-					}, scheduler::pipeline::server, 1s);
+					bot_team_join(entity_num);
 				}
 
 				scheduler::once([entity_num]()

--- a/src/client/module/party.cpp
+++ b/src/client/module/party.cpp
@@ -172,6 +172,14 @@ namespace party
 				start_map(argument[1]);
 			});
 
+			command::add("fast_restart", []()
+			{
+				if (game::SV_Loaded())
+				{
+					game::SV_FastRestart();
+				}
+			});
+
 			command::add("connect", [](command::params& argument)
 			{
 				if (argument.size() != 2)


### PR DESCRIPTION
to note: when restarting the map, spawned bots will stay but won't autojoin a team.
added bot_team which will check every 3 sec if bot is spectator then select team if is.

also when fast_restarting at the end of the match when scoreboard is visible the scoreboard will persist and won't go away.