### PR TITLE
Aim assist disable/enable dvars

### DIFF
--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -19,6 +19,9 @@ namespace dvars
 
 	game::dvar_t* pm_bouncing = nullptr;
 
+    game::dvar_t* sv_allow_aimassist = nullptr;
+    game::dvar_t* aimassist_enabled = nullptr;
+
     std::string dvar_get_vector_domain(const int components, const game::dvar_limits& domain)
     {
         if (domain.vector.min == -FLT_MAX)

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -20,6 +20,9 @@ namespace dvars
 
 	extern game::dvar_t* pm_bouncing;
 
+	extern game::dvar_t* sv_allow_aimassist;
+	extern game::dvar_t* aimassist_enabled;
+
 	std::string dvar_get_vector_domain(const int components, const game::dvar_limits& domain);
 	std::string dvar_get_domain(const game::dvar_type type, const game::dvar_limits& domain);
 }

--- a/src/client/module/patches.cpp
+++ b/src/client/module/patches.cpp
@@ -187,6 +187,38 @@ namespace patches
 		{
 			return game::R_RegisterFont("fonts/bigFont");
 		}
+
+		const auto aim_assist_add_to_target_list = utils::hook::assemble([](utils::hook::assembler& a)
+		{
+			const auto no_aa = a.newLabel();
+
+			// check server sided dvar
+			a.push(rax);
+			a.mov(rax, qword_ptr(reinterpret_cast<int64_t>(&dvars::sv_allow_aimassist)));
+			a.mov(al, byte_ptr(rax, 0x10));
+			a.cmp(al, 0);
+			a.pop(rax);
+			a.je(no_aa);
+
+			// if server allows aim assist, check if player has it disabled
+			a.push(rax);
+			a.mov(rax, qword_ptr(reinterpret_cast<int64_t>(&dvars::aimassist_enabled)));
+			a.mov(al, byte_ptr(rax, 0x10));
+			a.cmp(al, 0);
+			a.pop(rax);
+			a.je(no_aa);
+
+			// do aim assist
+			a.mov(ptr(rsp, 0x10), rsi);
+			a.push(rdi);
+			a.sub(rsp, 0x30);
+			a.mov(r11d, ptr(rcx, 0x12AC));
+			a.jmp(0x140139D91);
+
+			// no aim assist
+			a.bind(no_aa);
+			a.ret();
+		});
 	}
 
 	class module final : public module_interface
@@ -328,6 +360,10 @@ namespace patches
 			utils::hook::call(0x14025C825, get_chat_font_handle);
 			utils::hook::call(0x1402BC42F, get_chat_font_handle);
 			utils::hook::call(0x1402C3699, get_chat_font_handle);
+
+			dvars::aimassist_enabled = game::Dvar_RegisterBool("aimassist_enabled", true, game::DvarFlags::DVAR_FLAG_SAVED, "Enables aim assist for controllers"); //client side aim assist dvar
+			dvars::sv_allow_aimassist = game::Dvar_RegisterBool("sv_allow_aimassist", true, game::DvarFlags::DVAR_FLAG_REPLICATED, "Allow aim assist for controllers player in this server"); //server side aim assist dvar
+			utils::hook::jump(0x140139D80, aim_assist_add_to_target_list, true);
 		}
 
 		void patch_sp() const


### PR DESCRIPTION
sv_allow_aimassist - Allow servers to disable aim assist for all players in the server
aimassist_enabled - Allow players to disable aim assist for themselves while playing in servers