### PR TITLE
allow PlayerCmd_SetClientDvar to change any dvar like old cods

### DIFF
--- a/src/client/component/dvar_cheats.cpp
+++ b/src/client/component/dvar_cheats.cpp
@@ -1,8 +1,10 @@
 #include <std_include.hpp>
 #include "loader/component_loader.hpp"
 #include "utils/hook.hpp"
+#include "utils/string.hpp"
 #include "game/game.hpp"
 
+#include "command.hpp"
 #include "game_console.hpp"
 #include "scheduler.hpp"
 
@@ -106,6 +108,56 @@ namespace dvar_cheats
 		a.jmp(0x1404F0D74);
 	});
 
+	void cg_set_client_dvar_from_server(int local_client_num, game::mp::cg_s* cg, const char* dvar_id, const char* value)
+	{
+		const auto* dvar = game::Dvar_FindVar(dvar_id);
+		if (dvar)
+		{
+			// If we send as string, it can't be set with source SERVERCMD because the game only allows that source on real server cmd dvars. 
+			// Just use external instead as if it was being set by the console
+			game::Dvar_SetFromStringByNameFromSource(dvar_id, value, game::DvarSetSource::DVAR_SOURCE_EXTERNAL);
+		}
+		else
+		{
+			// Not a dvar name, assume it is an id and the game will handle normally
+			game::CG_SetClientDvarFromServer(local_client_num, cg, dvar_id, value);
+		}
+	}
+
+	void set_client_dvar_by_string(int entity_num, const char* value)
+	{
+		const auto* dvar = game::Scr_GetString(0); // grab the original dvar again since it's never stored on stack
+		const auto* command = utils::string::va("q %s \"%s\"", dvar, value);
+
+		game::SV_GameSendServerCommand(entity_num, 1, command);
+	}
+
+	const auto player_cmd_set_client_dvar = utils::hook::assemble([](utils::hook::assembler& a)
+	{
+		const auto set_by_string = a.newLabel();
+
+		a.pushad64();
+
+		// check if we didn't find a network dvar index
+		a.mov(ecx, dword_ptr(rsp, 0x8C8));
+		a.cmp(ecx, 0);
+		a.je(set_by_string);
+
+		// we found an index, handle normally
+		a.popad64();
+		a.mov(r8d, ptr(rsp, 0x848));
+		a.lea(r9, ptr(rsp, 0x30));
+		a.jmp(0x14038A5A7);
+
+		// no index, let's send the dvar as a string
+		a.bind(set_by_string);
+		a.movzx(ecx, word_ptr(rsp, 0x8C0)); //entity_num 
+		a.lea(rdx, ptr(rsp, 0xB0)); //value
+		a.call(set_client_dvar_by_string);
+		a.popad64();
+		a.jmp(0x14038A5CD);
+	});
+
 	class component final : public component_interface
 	{
 	public:
@@ -115,6 +167,11 @@ namespace dvar_cheats
 
 			utils::hook::nop(0x1404F0D13, 4); // let our stub handle zero-source sets
 			utils::hook::jump(0x1404F0D1A, dvar_flag_checks_stub, true); // check extra dvar flags when setting values
+
+			utils::hook::nop(0x14038A553, 5); // remove error in PlayerCmd_SetClientDvar if setting a non-network dvar
+			utils::hook::set<uint8_t>(0x14038A520, 0x1E); // don't check flags on the dvars, send any existing dvar instead
+			utils::hook::jump(0x14038A59A, player_cmd_set_client_dvar, true); // send non-network dvars as string
+			utils::hook::call(0x140287AED, cg_set_client_dvar_from_server); // check for dvars being sent as string before parsing ids
 			
 			scheduler::once([]()
 			{

--- a/src/client/component/dvar_cheats.cpp
+++ b/src/client/component/dvar_cheats.cpp
@@ -4,7 +4,6 @@
 #include "utils/string.hpp"
 #include "game/game.hpp"
 
-#include "command.hpp"
 #include "game_console.hpp"
 #include "scheduler.hpp"
 
@@ -108,7 +107,7 @@ namespace dvar_cheats
 		a.jmp(0x1404F0D74);
 	});
 
-	void cg_set_client_dvar_from_server(int local_client_num, game::mp::cg_s* cg, const char* dvar_id, const char* value)
+	void cg_set_client_dvar_from_server(const int local_client_num, game::mp::cg_s* cg, const char* dvar_id, const char* value)
 	{
 		const auto* dvar = game::Dvar_FindVar(dvar_id);
 		if (dvar)
@@ -124,7 +123,7 @@ namespace dvar_cheats
 		}
 	}
 
-	void set_client_dvar_by_string(int entity_num, const char* value)
+	void set_client_dvar_by_string(const int entity_num, const char* value)
 	{
 		const auto* dvar = game::Scr_GetString(0); // grab the original dvar again since it's never stored on stack
 		const auto* command = utils::string::va("q %s \"%s\"", dvar, value);

--- a/src/client/component/dvar_cheats.cpp
+++ b/src/client/component/dvar_cheats.cpp
@@ -153,7 +153,7 @@ namespace dvar_cheats
 		a.bind(set_by_string);
 		a.movzx(ecx, word_ptr(rsp, 0x8C0)); //entity_num 
 		a.lea(rdx, ptr(rsp, 0xB0)); //value
-		a.call(set_client_dvar_by_string);
+		a.call_aligned(set_client_dvar_by_string);
 		a.popad64();
 		a.jmp(0x14038A5CD);
 	});
@@ -167,7 +167,6 @@ namespace dvar_cheats
 
 			utils::hook::nop(0x1404F0D13, 4); // let our stub handle zero-source sets
 			utils::hook::jump(0x1404F0D1A, dvar_flag_checks_stub, true); // check extra dvar flags when setting values
-
 
 			utils::hook::nop(0x14038A553, 5); // remove error in PlayerCmd_SetClientDvar if setting a non-network dvar
 			utils::hook::set<uint8_t>(0x14038A520, 0x1E); // don't check flags on the dvars, send any existing dvar instead

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -29,7 +29,7 @@ namespace game
 	WEAK Symbol<bool ()> CL_IsCgameInitialized{0x140234DA0, 0x1402B9A70};
 
 	WEAK Symbol<void (int localClientNum, const char* message)> CG_GameMessage{0x1401F2E20, 0x140271320};
-	WEAK Symbol<void(int localClientNum, mp::cg_s* cg, const char* dvar, const char* value)> CG_SetClientDvarFromServer{0x0, 0x14028A2C0 };
+	WEAK Symbol<void (int localClientNum, mp::cg_s* cg, const char* dvar, const char* value)> CG_SetClientDvarFromServer{0x0, 0x14028A2C0 };
 
 	WEAK Symbol<void (const char* cmdName, void (), cmd_function_s* allocedCmd)> Cmd_AddCommandInternal{
 		0x1403B3570, 0x1403F7070
@@ -64,7 +64,7 @@ namespace game
 	WEAK Symbol<void (dvar_t* dvar, bool value)> Dvar_SetBool{0x14042C370, 0x1404EF1A0};
 	WEAK Symbol<void (const char* dvar, const char* buffer)> Dvar_SetCommand{0x14042C8E0, 0x1404EF790};
 	WEAK Symbol<void (dvar_t* dvar, const char* string)> Dvar_SetString{0x14042D6E0, 0x1404F08E0};
-	WEAK Symbol<void(const char*, const char*, DvarSetSource)> Dvar_SetFromStringByNameFromSource{0x14042D000, 0x1404F00B0};
+	WEAK Symbol<void (const char*, const char*, DvarSetSource)> Dvar_SetFromStringByNameFromSource{0x14042D000, 0x1404F00B0};
 	WEAK Symbol<void ()> Dvar_Sort{0x14042DEF0, 0x1404F1210};
 	WEAK Symbol<const char*(dvar_t* dvar, dvar_value value)> Dvar_ValueToString{0x14042E710, 0x1404F1A30};
 

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -29,6 +29,7 @@ namespace game
 	WEAK Symbol<bool ()> CL_IsCgameInitialized{0x140234DA0, 0x1402B9A70};
 
 	WEAK Symbol<void (int localClientNum, const char* message)> CG_GameMessage{0x1401F2E20, 0x140271320};
+	WEAK Symbol<void(int localClientNum, mp::cg_s* cg, const char* dvar, const char* value)> CG_SetClientDvarFromServer{0x0, 0x14028A2C0 };
 
 	WEAK Symbol<void (const char* cmdName, void (), cmd_function_s* allocedCmd)> Cmd_AddCommandInternal{
 		0x1403B3570, 0x1403F7070
@@ -63,6 +64,7 @@ namespace game
 	WEAK Symbol<void (dvar_t* dvar, bool value)> Dvar_SetBool{0x14042C370, 0x1404EF1A0};
 	WEAK Symbol<void (const char* dvar, const char* buffer)> Dvar_SetCommand{0x14042C8E0, 0x1404EF790};
 	WEAK Symbol<void (dvar_t* dvar, const char* string)> Dvar_SetString{0x14042D6E0, 0x1404F08E0};
+	WEAK Symbol<void(const char*, const char*, DvarSetSource)> Dvar_SetFromStringByNameFromSource{0x14042D000, 0x1404F00B0};
 	WEAK Symbol<void ()> Dvar_Sort{0x14042DEF0, 0x1404F1210};
 	WEAK Symbol<const char*(dvar_t* dvar, dvar_value value)> Dvar_ValueToString{0x14042E710, 0x1404F1A30};
 
@@ -114,6 +116,7 @@ namespace game
 	WEAK Symbol<unsigned int (unsigned int parentId, unsigned int name)> FindVariable{0x1403D84F0, 0x1404334A0};
 	WEAK Symbol<void (VariableValue *result, unsigned int classnum, int entnum, int offset)> GetEntityFieldValue{0x1403DC810, 0x140437860};
 	WEAK Symbol<const float * (const float *v)> Scr_AllocVector{0x1403D9AF0, 0x140434A10};
+	WEAK Symbol<const char* (int index)> Scr_GetString{0, 0x140439160};
 	WEAK Symbol<float (int index)> Scr_GetFloat{0, 0x140438D60};
 	WEAK Symbol<int ()> Scr_GetNumParam{0x1403DDF60, 0x140438EC0};
 	WEAK Symbol<void ()> Scr_ClearOutParams{0x1403DD500, 0x140438600};


### PR DESCRIPTION
This change allows SetClientDvar to change dvars that are not network dvars. On old cods it would send the SV_GameSendServerCommand with the dvar name as a string. On Ghosts, it converts the dvar name to an ID and sends that instead. The ID is only valid for network dvars (replicated & whatever 0x10 is). This will be handy for scripting when people make their own mods and need the ability to change client dvars