### PR TITLE
[RCON] Re-Added new line terminating character

### DIFF
--- a/src/client/component/rcon.cpp
+++ b/src/client/component/rcon.cpp
@@ -133,7 +133,7 @@ namespace rcon
 
 		if (is_redirecting_)
 		{
-			network::send(redirect_target_, "print", message);
+			network::send(redirect_target_, "print\n", message);
 			return true;
 		}
 		return false;


### PR DESCRIPTION
This should restore the old rcon behaviour the server had.

Tools like iw4m had always expected \xFF\xFF\xFF\xFFprint\n as a reply but the new line terminating character was removed.