### PR TITLE
[RCON] Minor refactoring

### DIFF
--- a/src/client/component/console.cpp
+++ b/src/client/component/console.cpp
@@ -50,16 +50,14 @@ namespace console
 
 		void dispatch_message(const int type, const std::string& message)
 		{
-			if (rcon::message_redirect(message))
+			if (!rcon::message_redirect(message))
 			{
-				return;
+				game_console::print(type, message);
+				messages.access([&message](message_queue& msgs)
+				{
+					msgs.emplace(message);
+				});
 			}
-
-			game_console::print(type, message);
-			messages.access([&message](message_queue& msgs)
-			{
-				msgs.emplace(message);
-			});
 		}
 
 		void append_text(const char* text)

--- a/src/client/component/console.cpp
+++ b/src/client/component/console.cpp
@@ -50,14 +50,16 @@ namespace console
 
 		void dispatch_message(const int type, const std::string& message)
 		{
-			if (!rcon::message_redirect(message))
+			if (rcon::message_redirect(message))
 			{
-				game_console::print(type, message);
-				messages.access([&message](message_queue& msgs)
-				{
-					msgs.emplace(message);
-				});
+				return;
 			}
+
+			game_console::print(type, message);
+			messages.access([&message](message_queue& msgs)
+			{
+				msgs.emplace(message);
+			});
 		}
 
 		void append_text(const char* text)

--- a/src/client/component/rcon.cpp
+++ b/src/client/component/rcon.cpp
@@ -34,34 +34,12 @@ namespace rcon
 			redirect_target_ = {};
 		}
 
-		int __cdecl print_stub(const char* fmt, ...)
-		{
-			std::lock_guard<std::recursive_mutex> $(redirect_lock);
-
-			static thread_local utils::string::va_provider<8, 256> provider;
-			va_list ap;
-			va_start(ap, fmt);
-			const char* result = provider.get(fmt, ap);
-			va_end(ap);
-
-			if (is_redirecting_)
-			{
-				network::send(redirect_target_, "print\n", result);
-			}
-			else
-			{
-				print_hook.invoke<int>(result);
-			}
-
-			return 0;
-		}
-
 		std::string build_status_buffer()
 		{
 			const auto sv_maxclients = game::Dvar_FindVar("sv_maxclients");
 			const auto mapname = game::Dvar_FindVar("mapname");
 
-			std::string buffer = ""s;
+			auto buffer = ""s;
 			buffer.append(utils::string::va("map: %s\n", mapname->current.string));
 			buffer.append(
 				"num score bot ping guid                             name             address               qport\n");
@@ -193,8 +171,6 @@ namespace rcon
 			}
 			else
 			{
-				//print_hook.create(reinterpret_cast<void*>(printf), &print_stub);
-
 				network::on("rcon", [](const game::netadr_s& addr, const std::string_view& data)
 				{
 					const auto message = std::string{data};

--- a/src/client/component/rcon.cpp
+++ b/src/client/component/rcon.cpp
@@ -16,7 +16,6 @@ namespace rcon
 		bool is_redirecting_ = false;
 		game::netadr_s redirect_target_ = {};
 		std::recursive_mutex redirect_lock;
-		utils::hook::detour print_hook;
 
 		void setup_redirect(const game::netadr_s& target)
 		{


### PR DESCRIPTION
After #395 print_stub function is no longer needed therefore I decided to remove it.

Also renamed build_status_buffer from std::string to auto to match all other variable declarations in the file.

Finally, I re-wrote an if statement so the code may be shorter in length and perhaps easier to read in my opinion.

Feel free to let me know if the "if statement" was originally written the way you prefer.