### PR TITLE
Hook disconnect command

### DIFF
--- a/src/client/component/party.cpp
+++ b/src/client/component/party.cpp
@@ -251,6 +251,9 @@ namespace party
 				return;
 			}
 
+			// hook disconnect command function
+			utils::hook::jump(0x1402C6370, disconnect_stub);
+
 			if (game::environment::is_mp())
 			{
 				// show custom drop reason


### PR DESCRIPTION
Previous PR contained a unused stub. But according to @fedddddd it's still necessary to port over from S1x. This PR adds the hook for this particular stub.
More information see https://github.com/XLabsProject/iw6x-client/pull/503