### PR TITLE
[Feature] Elevators

### DIFF
--- a/src/client/component/gameplay.cpp
+++ b/src/client/component/gameplay.cpp
@@ -166,6 +166,28 @@ namespace gameplay
 
 			a.jmp(0x140213494);
 		});
+
+		void pm_player_trace_stub(game::pmove_t* move, game::trace_t* trace, const float* f3,
+			const float* f4, const game::Bounds* bounds, int a6, int a7)
+		{
+			game::PM_playerTrace(move, trace, f3, f4, bounds, a6, a7);
+
+			if (dvars::g_enableElevators->current.enabled)
+			{
+				trace->startsolid = false;
+			}
+		}
+
+		void pm_trace_stub(const game::pmove_t* move, game::trace_t* trace, const float* f3,
+			const float* f4, const game::Bounds* bounds, int a6, int a7)
+		{
+			game::PM_trace(move, trace, f3, f4, bounds, a6, a7);
+
+			if (dvars::g_enableElevators->current.enabled)
+			{
+				trace->allsolid = false;
+			}
+		}
 	}
 
 	class component final : public component_interface
@@ -224,6 +246,12 @@ namespace gameplay
 			dvars::jump_ladderPushVel = game::Dvar_RegisterFloat("jump_ladderPushVel", 128.f, 0.f, 1024.f,
 			                                                     game::DvarFlags::DVAR_FLAG_REPLICATED,
 			                                                     "Ladder push velocity");
+
+			utils::hook::call(0x140221F92, pm_player_trace_stub);
+			utils::hook::call(0x140221FFA, pm_player_trace_stub);
+			utils::hook::call(0x14021F0E3, pm_trace_stub);
+			dvars::g_enableElevators = game::Dvar_RegisterBool("g_enableElevators", false,
+				game::DvarFlags::DVAR_FLAG_REPLICATED, "Enable Elevators");
 		}
 	};
 }

--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -19,6 +19,7 @@ namespace dvars
 	game::dvar_t* g_playerCollision = nullptr;
 	game::dvar_t* g_gravity = nullptr;
 	game::dvar_t* g_speed = nullptr;
+	game::dvar_t* g_enableElevators = nullptr;
 
 	game::dvar_t* pm_bouncing = nullptr;
 

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -19,6 +19,7 @@ namespace dvars
 	extern game::dvar_t* g_playerEjection;
 	extern game::dvar_t* g_gravity;
 	extern game::dvar_t* g_speed;
+	extern game::dvar_t* g_enableElevators;
 
 	extern game::dvar_t* pm_bouncing;
 

--- a/src/client/game/structs.hpp
+++ b/src/client/game/structs.hpp
@@ -2228,6 +2228,60 @@ namespace game
 		int forceTechType;
 	};
 
+	enum TraceHitType
+	{
+		TRACE_HITTYPE_NONE,
+		TRACE_HITTYPE_ENTITY,
+		TRACE_HITTYPE_DYNENT_MODEL,
+		TRACE_HITTYPE_DYNENT_BRUSH,
+		TRACE_HITTYPE_GLASS
+	};
+
+	struct trace_t
+	{
+		float fraction;
+		float normal[3];
+		int surfaceFlags;
+		int contents;
+		TraceHitType hitType;
+		unsigned __int16 hitId;
+		unsigned __int16 modelIndex;
+		scr_string_t partName;
+		unsigned __int16 partGroup;
+		bool allsolid;
+		bool startsolid;
+		bool walkable;
+		bool getPenetration;
+		bool removePitchAndRollRotations;
+	};
+
+	struct pmove_t
+	{
+		playerState_s* ps;
+		usercmd_s cmd;
+		usercmd_s oldcmd;
+		int tracemask;
+		int numtouch;
+		int touchents[32];
+		Bounds bounds;
+		float speed;
+		int contactEntity;
+		int proneChange;
+		bool mantleStarted;
+		float mantleEndPos[3];
+		int mantleDuration;
+		float meleeEntOrigin[3];
+		float meleeEntVelocity[3];
+		int viewChangeTime;
+		float viewChange;
+		float fTorsoPitch;
+		float fWaistPitch;
+		int remoteTurretFireTime;
+		int lastUpdateCMDServerTime;
+		unsigned int groundSurfaceType;
+		unsigned char handler;
+	};
+
 	namespace hks
 	{
 		struct GenericChunkHeader

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -239,6 +239,11 @@ namespace game
 
 	WEAK symbol<DWOnlineStatus (int)> dwGetLogOnStatus{0, 0x140589490};
 
+	WEAK symbol<void(pmove_t* move, trace_t*, const float*, const float*,
+		const Bounds*, int, int)> PM_playerTrace{0, 0x140225C20};
+	WEAK symbol<void(const pmove_t* move, trace_t* trace, const float*,
+		const float*, const Bounds*, int, int)> PM_trace{0, 0x140225DB0};
+
 	WEAK symbol<void*(jmp_buf* Buf, int Value)> longjmp{0x14062E030, 0x140738060};
 	WEAK symbol<int (jmp_buf* Buf)> _setjmp{0x14062F030, 0x140739060};
 


### PR DESCRIPTION
Adds dvar g_enableElevators.
If set to 1 elevators will be possible again.
Because the elevator glitch was patched this would be the only way to do it (as far as I am aware). I was told by many it makes sense to add this feature because some trickshotting servers might find it useful (as regular cod4 style elevators have been patched). I've seen trickshotting servers on IW5 make the same exact modification to the engine and when they were open they were somewhat popular.

Video: [YT](https://youtu.be/9DkHmDOy0No)

# Credits
 * [xoxor4d](https://github.com/xoxor4d) - I followed his research article about elevators on MW2. He also told me what he modified on other games to depatch elevators.