### PR TITLE
Bouncing from all angles

### DIFF
--- a/src/client/component/gameplay.cpp
+++ b/src/client/component/gameplay.cpp
@@ -67,7 +67,7 @@ namespace gameplay
 
 			a.push(rax);
 
-			a.mov(rax, qword_ptr(reinterpret_cast<int64_t>(&dvars::bg_bouncing)));
+			a.mov(rax, qword_ptr(reinterpret_cast<int64_t>(&dvars::pm_bouncing)));
 			a.mov(al, byte_ptr(rax, 0x10));
 			a.cmp(ptr(rbp, -0x40), al);
 
@@ -91,7 +91,7 @@ namespace gameplay
 
 			a.push(rax);
 
-			a.mov(rax, qword_ptr(reinterpret_cast<int64_t>(&dvars::bg_bouncing)));
+			a.mov(rax, qword_ptr(reinterpret_cast<int64_t>(&dvars::pm_bouncing)));
 			a.mov(al, byte_ptr(rax, 0x10));
 			a.cmp(byte_ptr(rbp, -0x38), al);
 
@@ -126,7 +126,7 @@ namespace gameplay
 			const auto length_scale = std::sqrtf((velIn[2] * velIn[2] + length_squared_2d)
 				/ (new_z * new_z + length_squared_2d));
 
-			if (dvars::bg_bouncingAllAngles->current.enabled
+			if (dvars::pm_bouncingAllAngles->current.enabled
 				|| (length_scale < 1.f || new_z < 0.f || velIn[2] > 0.f))
 			{
 				velOut[0] = velIn[0] * length_scale;
@@ -230,11 +230,11 @@ namespace gameplay
 
 			utils::hook::jump(
 				SELECT_VALUE(0x14046EC5C, 0x140228FFF), SELECT_VALUE(pm_bouncing_stub_sp, pm_bouncing_stub_mp), true);
-			dvars::bg_bouncing = game::Dvar_RegisterBool("bg_bouncing", false,
+			dvars::pm_bouncing = game::Dvar_RegisterBool("pm_bouncing", false,
 			                                             game::DvarFlags::DVAR_FLAG_REPLICATED, "Enable bouncing");
 
 			utils::hook::call(SELECT_VALUE(0x14046ED6A, 0x1402290D0), pm_project_velocity_stub);
-			dvars::bg_bouncingAllAngles = game::Dvar_RegisterBool("bg_bouncingAllAngles", false,
+			dvars::pm_bouncingAllAngles = game::Dvar_RegisterBool("pm_bouncingAllAngles", false,
 				game::DvarFlags::DVAR_FLAG_REPLICATED, "Enable bouncing from all angles");
 
 			if (game::environment::is_sp()) return;

--- a/src/client/component/gameplay.cpp
+++ b/src/client/component/gameplay.cpp
@@ -108,30 +108,30 @@ namespace gameplay
 			a.jmp(0x140228FB8);
 		});
 
-		void pm_project_velocity_stub(const float* velIn, const float* normal, float* velOut)
+		void pm_project_velocity_stub(const float* vel_in, const float* normal, float* vel_out)
 		{
-			const auto length_squared_2d = velIn[0] * velIn[0] + velIn[1] * velIn[1];
+			const auto length_squared_2d = vel_in[0] * vel_in[0] + vel_in[1] * vel_in[1];
 
 			if (std::fabsf(normal[2]) < 0.001f || length_squared_2d == 0.0)
 			{
-				velOut[0] = velIn[0];
-				velOut[1] = velIn[1];
-				velOut[2] = velIn[2];
+				vel_out[0] = vel_in[0];
+				vel_out[1] = vel_in[1];
+				vel_out[2] = vel_in[2];
 				return;
 			}
 
-			auto new_z = velIn[0] * normal[0] + velIn[1] * normal[1];
+			auto new_z = vel_in[0] * normal[0] + vel_in[1] * normal[1];
 			new_z = -new_z / normal[2];
 
-			const auto length_scale = std::sqrtf((velIn[2] * velIn[2] + length_squared_2d)
+			const auto length_scale = std::sqrtf((vel_in[2] * vel_in[2] + length_squared_2d)
 				/ (new_z * new_z + length_squared_2d));
 
 			if (dvars::pm_bouncingAllAngles->current.enabled
-				|| (length_scale < 1.f || new_z < 0.f || velIn[2] > 0.f))
+				|| (length_scale < 1.f || new_z < 0.f || vel_in[2] > 0.f))
 			{
-				velOut[0] = velIn[0] * length_scale;
-				velOut[1] = velIn[1] * length_scale;
-				velOut[2] = new_z * length_scale;
+				vel_out[0] = vel_in[0] * length_scale;
+				vel_out[1] = vel_in[1] * length_scale;
+				vel_out[2] = new_z * length_scale;
 			}
 		}
 

--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -21,8 +21,8 @@ namespace dvars
 	game::dvar_t* g_speed = nullptr;
 	game::dvar_t* g_enableElevators = nullptr;
 
-	game::dvar_t* bg_bouncing = nullptr;
-	game::dvar_t* bg_bouncingAllAngles = nullptr;
+	game::dvar_t* pm_bouncing = nullptr;
+	game::dvar_t* pm_bouncingAllAngles = nullptr;
 
 	game::dvar_t* jump_slowDownEnable = nullptr;
 	game::dvar_t* jump_enableFallDamage = nullptr;

--- a/src/client/game/dvars.cpp
+++ b/src/client/game/dvars.cpp
@@ -21,7 +21,8 @@ namespace dvars
 	game::dvar_t* g_speed = nullptr;
 	game::dvar_t* g_enableElevators = nullptr;
 
-	game::dvar_t* pm_bouncing = nullptr;
+	game::dvar_t* bg_bouncing = nullptr;
+	game::dvar_t* bg_bouncingAllAngles = nullptr;
 
 	game::dvar_t* jump_slowDownEnable = nullptr;
 	game::dvar_t* jump_enableFallDamage = nullptr;

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -21,8 +21,8 @@ namespace dvars
 	extern game::dvar_t* g_speed;
 	extern game::dvar_t* g_enableElevators;
 
-	extern game::dvar_t* bg_bouncing;
-	extern game::dvar_t* bg_bouncingAllAngles;
+	extern game::dvar_t* pm_bouncing;
+	extern game::dvar_t* pm_bouncingAllAngles;
 
 	extern game::dvar_t* r_aspectRatioCustom;
 	extern game::dvar_t* jump_slowDownEnable;

--- a/src/client/game/dvars.hpp
+++ b/src/client/game/dvars.hpp
@@ -21,7 +21,8 @@ namespace dvars
 	extern game::dvar_t* g_speed;
 	extern game::dvar_t* g_enableElevators;
 
-	extern game::dvar_t* pm_bouncing;
+	extern game::dvar_t* bg_bouncing;
+	extern game::dvar_t* bg_bouncingAllAngles;
 
 	extern game::dvar_t* r_aspectRatioCustom;
 	extern game::dvar_t* jump_slowDownEnable;

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -240,7 +240,7 @@ namespace game
 	WEAK symbol<DWOnlineStatus (int)> dwGetLogOnStatus{0, 0x140589490};
 
 	WEAK symbol<void(pmove_t* move, trace_t*, const float*, const float*,
-		const Bounds*, int, int)> PM_playerTrace{0, 0x140225C20};
+		const Bounds*, int, int)> PM_playerTrace{0x14046C910, 0x140225C20};
 	WEAK symbol<void(const pmove_t* move, trace_t* trace, const float*,
 		const float*, const Bounds*, int, int)> PM_trace{0, 0x140225DB0};
 


### PR DESCRIPTION
- bg_bouncingAllAngles, this forces the game to make the player bounce more easily (won't work unless the other dvar is set to true)
- pm_bouncing is renamed to bg_bouncing as the pm_prefix is non-standard. bg = both games, dvars are replicated so it is a more fitting prefix.

- Well tested

This feature comes from IW4x  where it was thoroughly tested by people other than me (https://github.com/XLabsProject/iw4x-client/pull/158). The engine behaves the same way on this game too so it was a straightforward port.