### PR TITLE
Fix potential LUI scripting crash

### DIFF
--- a/src/client/component/server_list.cpp
+++ b/src/client/component/server_list.cpp
@@ -111,8 +111,8 @@ namespace server_list
 			return static_cast<int>(servers.size() - server_list_index);
 		}
 
-		const char* ui_feeder_item_text(int /*localClientNum*/, void* /*a2*/, void* /*a3*/, const size_t index,
-		                                const size_t column)
+		const char* ui_feeder_item_text(int /*localClientNum*/, void* /*a2*/, void* /*a3*/, const int index,
+		                                const int column)
 		{
 			std::lock_guard<std::mutex> _(mutex);
 

--- a/src/client/component/ui_scripting.cpp
+++ b/src/client/component/ui_scripting.cpp
@@ -137,12 +137,10 @@ namespace ui_scripting
 
 			scheduler::loop([]()
 			{
-				if (!game::Sys_IsMainThread())
+				if (game::Sys_IsMainThread())
 				{
-					return;
+					ui_scripting::lua::engine::run_frame();
 				}
-
-				ui_scripting::lua::engine::run_frame();
 			}, scheduler::pipeline::renderer);
 
 			hks_start_hook.create(0x1401D8E90, hks_start_stub);

--- a/src/client/component/ui_scripting.cpp
+++ b/src/client/component/ui_scripting.cpp
@@ -135,7 +135,15 @@ namespace ui_scripting
 				return;
 			}
 
-			scheduler::loop(ui_scripting::lua::engine::run_frame, scheduler::pipeline::renderer);
+			scheduler::loop([]()
+			{
+				if (!game::Sys_IsMainThread())
+				{
+					return;
+				}
+
+				ui_scripting::lua::engine::run_frame();
+			}, scheduler::pipeline::renderer);
 
 			hks_start_hook.create(0x1401D8E90, hks_start_stub);
 			hks_shutdown_hook.create(0x1401D24A0, hks_shutdown_stub);

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -229,6 +229,7 @@ namespace game
 	WEAK symbol<void()> Sys_ShowConsole{0x14043E650, 0x140503130};
 	WEAK symbol<bool (int, void const*, const netadr_s*)> Sys_SendPacket{0x14043D000, 0x140501A00};
 	WEAK symbol<void*(int valueIndex)> Sys_GetValue{0x1403C2C30, 0x1404237D0};
+	WEAK symbol<bool()> Sys_IsMainThread{0x1478FC470, 0x140423950};
 
 	WEAK symbol<void ()> SwitchToCoreMode{0, 0x1401FA4A0};
 	WEAK symbol<void ()> SwitchToAliensMode{0, 0x1401FA4D0};


### PR DESCRIPTION
Never got this crash on iw6x or s1x but I did on h2-mod (MW2CR), happened occasionally when leaving a mission. LUI starts up from the main thread while `r_endframe` (which then calls ui_scripting::run_frame) is being called from the render thread.
I also changed `size_t` to `int` in `server_list` `ui_feeder_item_text` since I noticed the values for the ping column were gone and this was due to the comparison between those two types not working anymore for some reason.