### PR TITLE
Fix sending packets longer than 1288 bytes

### DIFF
--- a/src/client/component/network.cpp
+++ b/src/client/component/network.cpp
@@ -101,10 +101,10 @@ namespace network
 		get_callbacks()[utils::string::to_lower(command)] = callback;
 	}
 
-	int dw_send_to_stub(const int size, const char* src, game::netadr_s* a3)
+	int dw_send_to_stub(const int size, const char* src, game::netadr_s* addr)
 	{
 		sockaddr s = {};
-		game::NetadrToSockadr(a3, &s);
+		game::NetadrToSockadr(addr, &s);
 		return sendto(*game::query_socket, src, size, 0, &s, 16) >= 0;
 	}
 

--- a/src/client/component/network.cpp
+++ b/src/client/component/network.cpp
@@ -101,6 +101,13 @@ namespace network
 		get_callbacks()[utils::string::to_lower(command)] = callback;
 	}
 
+	int dw_send_to_stub(const int size, const char* src, game::netadr_s* a3)
+	{
+		sockaddr s = {};
+		game::NetadrToSockadr(a3, &s);
+		return sendto(*game::query_socket, src, size, 0, &s, 16) >= 0;
+	}
+
 	void send(const game::netadr_s& address, const std::string& command, const std::string& data, const char separator)
 	{
 		std::string packet = "\xFF\xFF\xFF\xFF";
@@ -204,7 +211,7 @@ namespace network
 				}
 
 				// redirect dw_sendto to raw socket
-				utils::hook::jump(0x140501AAA, reinterpret_cast<void*>(0x140501A3A));
+				utils::hook::jump(0x140501A00, dw_send_to_stub);
 
 				// intercept command handling
 				utils::hook::jump(0x1402C64CB, utils::hook::assemble(handle_command_stub), true);

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -157,6 +157,7 @@ namespace game
 		0, 0x14041D780
 	};
 	WEAK symbol<bool (const char* s, game::netadr_s* a)> NET_StringToAdr{0, 0x14041D870};
+	WEAK symbol<void(netadr_s*, sockaddr*)> NetadrToSockadr{ 0, 0x1404E53D0 };
 
 	WEAK symbol<void (float x, float y, float width, float height, float s0, float t0, float s1, float t1,
 	                  float* color, Material* material)> R_AddCmdDrawStretchPic{0x140234460, 0x140600BE0};

--- a/src/client/game/symbols.hpp
+++ b/src/client/game/symbols.hpp
@@ -157,7 +157,7 @@ namespace game
 		0, 0x14041D780
 	};
 	WEAK symbol<bool (const char* s, game::netadr_s* a)> NET_StringToAdr{0, 0x14041D870};
-	WEAK symbol<void(netadr_s*, sockaddr*)> NetadrToSockadr{ 0, 0x1404E53D0 };
+	WEAK symbol<void(netadr_s*, sockaddr*)> NetadrToSockadr{0, 0x1404E53D0};
 
 	WEAK symbol<void (float x, float y, float width, float height, float s0, float t0, float s1, float t1,
 	                  float* color, Material* material)> R_AddCmdDrawStretchPic{0x140234460, 0x140600BE0};


### PR DESCRIPTION
fixes #204 / #606. redirects Sys_SendPacket to go straight to raw socket without trying to copy data to limited buffer first