### PR TITLE
Move sol2 specific warning to where it's needed

### DIFF
--- a/src/client/game/scripting/lua/context.hpp
+++ b/src/client/game/scripting/lua/context.hpp
@@ -4,6 +4,7 @@
 
 #pragma warning(push)
 #pragma warning(disable: 4702)
+#pragma warning(disable: 5056)
 
 #define SOL_ALL_SAFETIES_ON 1
 #define SOL_PRINT_ERRORS 0

--- a/src/client/std_include.hpp
+++ b/src/client/std_include.hpp
@@ -15,7 +15,6 @@
 #pragma warning(disable: 4702)
 #pragma warning(disable: 4996)
 #pragma warning(disable: 5054)
-#pragma warning(disable: 5056)
 #pragma warning(disable: 6011)
 #pragma warning(disable: 6297)
 #pragma warning(disable: 6385)


### PR DESCRIPTION
When I updated the project to c++20 dialect I made the mistake to place a #pragma warning(disable: 5056) in the global preached header.
This is not good as the warning is legit.
Sol2 claims only to support c++17 https://github.com/ThePhD/sol2#supported-compilers

So this pull request will disable this c++20 warning only where it's needed and leave it on for the rest of the project